### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This code has been developed with
   - numpy 1.17.2
   - snorkel 0.9.1
   - tensorflow_hub 0.7.0
+  - networkx 2.3.0
 
 # Data Description
 We have currently released processed version of 4 datastes used in our paper. 


### PR DESCRIPTION
if we dont use only networkx 2.3.0 it shows the following error:- Traceback (most recent call last):
  File "run_snorkel.py", line 79, in <module>
    label_model.fit(L_train=U_lsnork, n_epochs=1000, lr=0.001, log_freq=100, seed=123)
  File "/home/mool/anaconda3/envs/ICLR2020/lib/python3.6/site-packages/snorkel/labeling/model/label_model.py", line 854, in fit
    self._create_tree()
  File "/home/mool/anaconda3/envs/ICLR2020/lib/python3.6/site-packages/snorkel/labeling/model/label_model.py", line 575, in _create_tree
    self.c_tree = get_clique_tree(nodes, [])
  File "/home/mool/anaconda3/envs/ICLR2020/lib/python3.6/site-packages/snorkel/labeling/model/graph_utils.py", line 49, in get_clique_tree
    S = G2.node[i]["members"].intersection(G2.node[j]["members"])
AttributeError: 'Graph' object has no attribute 'node'